### PR TITLE
Status is active even if pebble services are already configured

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -2,12 +2,10 @@ type: "charm"
 bases:
   - build-on:
     - name: "ubuntu"
-      channel: "20.04"
-    - name: "ubuntu"
       channel: "22.04"
     run-on:
     - name: "ubuntu"
-      channel: "20.04"
+      channel: "22.04"
 parts:
   charm:
     charm-binary-python-packages:

--- a/lib/charms/magma_orc8r_libs/v0/orc8r_base.py
+++ b/lib/charms/magma_orc8r_libs/v0/orc8r_base.py
@@ -67,7 +67,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 13
+LIBPATCH = 14
 
 
 logger = logging.getLogger(__name__)
@@ -131,7 +131,7 @@ class Orc8rBase(Object):
                 self.container.restart(self.service_name)
                 logger.info(f"Restarted container {self.service_name}")
                 self._update_relations()
-                self.charm.unit.status = ActiveStatus()
+            self.charm.unit.status = ActiveStatus()
         else:
             self.charm.unit.status = WaitingStatus("Waiting for container to be ready...")
             event.defer()

--- a/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
+++ b/lib/charms/magma_orc8r_libs/v0/orc8r_base_db.py
@@ -85,7 +85,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 13
+LIBPATCH = 14
 
 
 logger = logging.getLogger(__name__)
@@ -163,7 +163,7 @@ class Orc8rBase(Object):
                 self.container.restart(self.service_name)
                 logger.info(f"Restarted container {self.service_name}")
                 self._update_relations()
-                self.charm.unit.status = ActiveStatus()
+            self.charm.unit.status = ActiveStatus()
         else:
             self.charm.unit.status = WaitingStatus("Waiting for container to be ready...")
             event.defer()

--- a/tests/test_orc8r_base.py
+++ b/tests/test_orc8r_base.py
@@ -2,9 +2,12 @@
 # See LICENSE file for licensing details.
 
 import unittest
-from unittest.mock import Mock, PropertyMock, patch
+from unittest.mock import Mock, patch
 
+import yaml
 from ops import testing
+from ops.model import ActiveStatus
+from ops.pebble import Plan
 from test_orc8r_base_charm.src.charm import (  # type: ignore[import]
     MagmaOrc8rDummyCharm,
     MagmaOrc8rDummyCharmWithRequiredRelation,
@@ -17,16 +20,15 @@ class TestCharm(unittest.TestCase):
         lambda charm, ports, additional_labels: None,
     )
     def setUp(self):
+        self.namespace = "banana"
         self.harness = testing.Harness(MagmaOrc8rDummyCharm)
+        self.harness.set_model_name(self.namespace)
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()
 
-    @patch("charms.magma_orc8r_libs.v0.orc8r_base.Orc8rBase.namespace", new_callable=PropertyMock)
     def test_given_pebble_ready_when_get_pebble_plan_then_plan_is_filled_with_orc8r_service_content(  # noqa: E501
-        self, patch_namespace
+        self,
     ):
-        namespace = "whatever"
-        patch_namespace.return_value = namespace
         expected_plan = {
             "services": {
                 "magma-orc8r-dummy": {
@@ -41,7 +43,7 @@ class TestCharm(unittest.TestCase):
                     "environment": {
                         "SERVICE_HOSTNAME": "magma-orc8r-dummy",
                         "SERVICE_REGISTRY_MODE": "k8s",
-                        "SERVICE_REGISTRY_NAMESPACE": namespace,
+                        "SERVICE_REGISTRY_NAMESPACE": self.namespace,
                     },
                 }
             },
@@ -50,6 +52,40 @@ class TestCharm(unittest.TestCase):
 
         updated_plan = self.harness.get_container_pebble_plan("magma-orc8r-dummy").to_dict()
         self.assertEqual(expected_plan, updated_plan)
+
+    def test_given_pebble_plan_not_yet_set_when_pebble_ready_then_status_is_active(self):
+        self.harness.container_pebble_ready("magma-orc8r-dummy")
+
+        self.assertEqual(self.harness.charm.unit.status, ActiveStatus())
+
+    @patch("ops.model.Container.get_plan")
+    def test_given_pebble_plan_already_set_when_pebble_ready_then_status_is_active(
+        self, patch_get_plan
+    ):
+        pebble_plan = {
+            "services": {
+                "magma-orc8r-dummy": {
+                    "override": "replace",
+                    "summary": "magma-orc8r-dummy",
+                    "startup": "enabled",
+                    "command": "/usr/bin/envdir "
+                    "/var/opt/magma/envdir "
+                    "/var/opt/magma/bin/dummy "
+                    "-logtostderr=true "
+                    "-v=0",
+                    "environment": {
+                        "SERVICE_HOSTNAME": "magma-orc8r-dummy",
+                        "SERVICE_REGISTRY_MODE": "k8s",
+                        "SERVICE_REGISTRY_NAMESPACE": self.namespace,
+                    },
+                }
+            }
+        }
+
+        patch_get_plan.return_value = Plan(raw=yaml.dump(pebble_plan))
+        self.harness.container_pebble_ready("magma-orc8r-dummy")
+
+        self.assertEqual(self.harness.charm.unit.status, ActiveStatus())
 
     def test_given_workload_not_running_when_relation_joined_then_service_status_is_marked_as_not_active_in_relation_data(  # noqa: E501
         self,
@@ -84,10 +120,6 @@ class TestCharm(unittest.TestCase):
         expected_relation_data = {"active": "True"}
         self.assertEqual(expected_relation_data, relation_data)
 
-    @patch(
-        "charms.magma_orc8r_libs.v0.orc8r_base.Orc8rBase.namespace",
-        PropertyMock(return_value="qwerty"),
-    )
     def test_given_magma_orc8r_orchestrator_service_running_when_metrics_magma_orc8r_orchestrator_relation_joined_event_emitted_then_active_key_in_relation_data_is_set_to_true(  # noqa: E501
         self,
     ):
@@ -95,24 +127,20 @@ class TestCharm(unittest.TestCase):
         container = self.harness.model.unit.get_container("magma-orc8r-dummy")
         self.harness.charm.on.magma_orc8r_dummy_pebble_ready.emit(container)
         self.harness.set_leader(True)
-        relation_id = self.harness.add_relation("magma-orc8r-dummy", "orc8r-dummy")
-        self.harness.add_relation_unit(relation_id, "magma-orc8r-dummy/0")
+        relation_id = self.harness.add_relation("magma-orc8r-dummy", "remote-app")
+        self.harness.add_relation_unit(relation_id, "remote-app/0")
 
         self.assertEqual(
             self.harness.get_relation_data(relation_id, "magma-orc8r-dummy/0"),
             {"active": "True"},
         )
 
-    @patch(
-        "charms.magma_orc8r_libs.v0.orc8r_base.Orc8rBase.namespace",
-        PropertyMock(return_value="qwerty"),
-    )
     def test_given_magma_orc8r_orchestrator_service_not_running_when_magma_orc8r_orchestrator_relation_joined_event_emitted_then_active_key_in_relation_data_is_set_to_false(  # noqa: E501
         self,
     ):
         self.harness.set_leader(True)
-        relation_id = self.harness.add_relation("magma-orc8r-dummy", "orc8r-dummy")
-        self.harness.add_relation_unit(relation_id, "magma-orc8r-dummy/0")
+        relation_id = self.harness.add_relation("magma-orc8r-dummy", "remote-app")
+        self.harness.add_relation_unit(relation_id, "remote-app/0")
 
         self.assertEqual(
             self.harness.get_relation_data(relation_id, "magma-orc8r-dummy/0"),


### PR DESCRIPTION
This PR addresses a bug observed [here](https://github.com/canonical/charmed-magma/issues/22) where charms would go to MaintenanceStatus after a while. This seems to be caused by the fact that if pods get restarted, their pebble plan might already be applied and they wouldn't go back to status. 